### PR TITLE
Add ability to return priorties from Jira

### DIFF
--- a/Jira/Api.php
+++ b/Jira/Api.php
@@ -164,6 +164,16 @@ class Jira_Api
         return $result;
     }
 
+    /**
+     * get available priorities
+     *
+     * @return mixed
+     */
+    public function getPriorties()
+    {
+    	$result = $this->api(self::REQUEST_GET, "/rest/api/2/priority", array(), true);
+    	return $result;
+    }
 
     /**
      * create an issue.


### PR DESCRIPTION
This adds the ability to return an array of priorities from /rest/api/2/priority

Change-Id: If2fcc761d7b3a31ea2e3e83759974fb5873b2bfc
