### PR TITLE
Add expand parameter to getCreateMeta()

### DIFF
--- a/src/Jira/Api.php
+++ b/src/Jira/Api.php
@@ -185,6 +185,7 @@ class Api
      * Returns the meta data for creating issues. This includes the available projects, issue types
      * and fields, including field types and whether or not those fields are required.
      * Projects will not be returned if the user does not have permission to create issues in that project.
+     * Fields will only be returned if "projects.issuetypes.fields" is added as expand parameter.
      *
      * @param $projectIds array      Combined with the projectKeys param, lists the projects with which to filter the results.
      *                               If absent, all projects are returned. Specifiying a project that does not exist (or that
@@ -199,17 +200,19 @@ class Api
      *                               If null, all issue types are returned. This parameter can be specified multiple times,
      *                               but is NOT interpreted as a comma-separated list. Specifiying an issue type that does
      *                               not exist is not an error.
+     * @param $expand array          Optional list of entities to expand in the response.
      * @return string
      */
     public function getCreateMeta(
         array $projectIds = null,
         array $projectKeys = null,
         array $issuetypeIds = null,
-        array $issuetypeNames = null
+        array $issuetypeNames = null,
+        array $expand = null
     ) {
         // Create comma seperated query parameters for the supplied filters
         $data = array();
-        foreach (array("projectIds", "projectKeys", "issuetypeIds", "issuetypeNames") as $parameterName)
+        foreach (array("projectIds", "projectKeys", "issuetypeIds", "issuetypeNames", "expand") as $parameterName)
             if (${$parameterName} !== null) {
                 $data[$parameterName] = implode(",", ${$parameterName});
             }


### PR DESCRIPTION
The [createmeta method](https://developer.atlassian.com/static/rest/jira/6.0.html#id164910) accepts an [expand parameter](https://developer.atlassian.com/static/rest/jira/6.0.html#expansion).

This is needed if I want to expand fields in the response.