### PR TITLE
fix exception when jira returns 201 http status

### DIFF
--- a/src/Jira/Api/Client/CurlClient.php
+++ b/src/Jira/Api/Client/CurlClient.php
@@ -102,7 +102,7 @@ class CurlClient implements ClientInterface
         if (curl_getinfo($curl, CURLINFO_HTTP_CODE) == 401) {
             throw new UnauthorizedException("Unauthorized");
         }
-        if ($data === '' && curl_getinfo($curl, CURLINFO_HTTP_CODE) != 204) {
+	if ($data === '' && !in_array(curl_getinfo($curl, CURLINFO_HTTP_CODE), array(201,204))) {
             throw new Exception("JIRA Rest server returns unexpected result.");
         }
 


### PR DESCRIPTION
When creating link ('/rest/api/2/issueLink') jira responds with 201 http status

```
Hostname jira.inn.ru was found in DNS cache
*   Trying 10.33.61.56...
* Connected to jira.inn.ru (10.33.61.56) port 443 (#0)
* successfully set certificate verify locations:
*   CAfile: /usr/local/etc/openssl/cert.pem
  CApath: none
* SSL connection using TLSv1.0 / DHE-RSA-AES256-SHA
* Server certificate:
* 	 SSL certificate verify ok.
* Server auth using Basic with user '***'
> POST /rest/api/2/issueLink HTTP/1.0
Authorization: Basic ******************==
Host: jira.lan
Accept: */*
Content-Type: application/json;charset=UTF-8
Content-Length: 254

* upload completely sent off: 254 out of 254 bytes
< HTTP/1.1 201 Created
< Server: nginx
< Date: Fri, 13 Mar 2015 15:31:58 GMT
< Content-Type: application/json;charset=UTF-8
< Connection: close
< X-AREQUESTID: 1111x2877207x1
< Set-Cookie: JSESSIONID=81010D8AAA797C4770264CFAB04ECC52; Path=/; HttpOnly
< X-Seraph-LoginReason: OK
< Set-Cookie: atlassian.xsrf.token=A8VA-9P0X-2O2K-7XMB|8c8317337c3dd8e6f74051349cd8873ec14bd0f3|lin; Path=/
< X-ASESSIONID: 18ilayz
< X-AUSERNAME: roman.kolohanin
< Location: https://jira.inn.ru/rest/api/2/issueLink/30198
< Cache-Control: no-cache, no-store, no-transform
< Content-Length: 0
<
* Closing connection 0
```

Exception 'chobie\Jira\Api\Exception' with message 'JIRA Rest server returns unexpected result.'

in /dev/vendor/chobie/jira-api-restclient/src/Jira/Api/Client/CurlClient.php:106
