### PR TITLE
fix typo in function name

### DIFF
--- a/src/Jira/Api.php
+++ b/src/Jira/Api.php
@@ -300,7 +300,7 @@ class Api
      *
      * @return mixed
      */
-    public function getPriorties()
+    public function getPriorities()
     {
         if (!count($this->priorities)) {
             $priorities = array();


### PR DESCRIPTION
fix typo

getPriorties() should be getPriorities()