### PR TITLE
Add method to create remote links for an issue

### DIFF
--- a/src/Jira/Api.php
+++ b/src/Jira/Api.php
@@ -441,6 +441,38 @@ class Api
     }
 
     /**
+     * create a remote link
+     *
+     * @param $issue
+     * @param array $object
+     * @param string $relationship
+     * @param string globalid
+     * @param array $application
+     * @return mixed
+     */
+    public function createRemotelink(
+            $issue,
+            $object = array(),
+            $relationship = null,
+            $globalid = null,
+            $application = null
+    ) {
+        $options = array(
+                        "globalid" => $globalid,
+                        "relationship" => $relationship,
+                        "object" => $object
+                    );
+
+        if (!is_null($application)) {
+            $options['application'] = $application;
+        }
+
+        return $this->api(self::REQUEST_POST,
+                            "/rest/api/2/issue/" . $issue . "/remotelink",
+                            $options, true);
+    }
+
+    /**
      * send request to specified host
      *
      * @param string $method


### PR DESCRIPTION
This method allows the user to add remote links to an issue. Remote link
point to systems other than JIRA itself, e.g. a web site or a wiki
page.

Creating links between JIRA issues accomplished by a different API and
thus beyond the scope of this method.