### PR TITLE
Fix create attachments for PHP 5.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor
 composer.lock
+.idea/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Jira Api Rest Client
 
-[![Build Status](https://secure.travis-ci.org/chobie/jira-api-restclient.png)](http://travis-ci.org/chobie/jira-api-restclient)
-
+This fork is meant to fix an incompatibility issue with PHP 5.5 and is published because pull requests are not processed.
 
 you know JIRA5 supports REST API. this is very useful to make some custom notifications and automated jobs.
 (JIRA also supports email notification, but it's too much to custom templates, notification timing. unfortunately it requires Administration permission.)
@@ -12,7 +11,7 @@ this API library will help your problems regarding JIRA. hope you enjoy it.
 composer.json
 
 ```
-composer require chobie/jira-api-restclient 2.0.*
+composer require DerMika/jira-api-restclient dev-master
 ```
 
 

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "chobie/jira-api-restclient",
+    "name": "dermika/jira-api-restclient",
     "description": "JIRA REST API.",
     "keywords": ["jira","rest","api"],
     "type": "library",
@@ -9,6 +9,10 @@
             "name": "Shuhei Tanuma",
             "homepage": "http://chobie.github.io/",
             "email": "chobieeee@php.net"
+        },
+		{
+            "name": "DerMika",
+            "email": "dieter@dermika.be"
         }
     ],
     "minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "chobie/jira-api-restclient",
+    "name": "DerMika/jira-api-restclient",
     "description": "JIRA REST API.",
     "keywords": ["jira","rest","api"],
     "type": "library",
@@ -9,6 +9,10 @@
             "name": "Shuhei Tanuma",
             "homepage": "http://chobie.github.io/",
             "email": "chobieeee@php.net"
+        },
+		{
+            "name": "DerMika",
+            "email": "dieter@dermika.be"
         }
     ],
     "minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "DerMika/jira-api-restclient",
+    "name": "dermika/jira-api-restclient",
     "description": "JIRA REST API.",
     "keywords": ["jira","rest","api"],
     "type": "library",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "dermika/jira-api-restclient",
+    "name": "chobie/jira-api-restclient",
     "description": "JIRA REST API.",
     "keywords": ["jira","rest","api"],
     "type": "library",
@@ -9,10 +9,6 @@
             "name": "Shuhei Tanuma",
             "homepage": "http://chobie.github.io/",
             "email": "chobieeee@php.net"
-        },
-		{
-            "name": "DerMika",
-            "email": "dieter@dermika.be"
         }
     ],
     "minimum-stability": "dev",

--- a/src/Jira/Api/Client/CurlClient.php
+++ b/src/Jira/Api/Client/CurlClient.php
@@ -42,13 +42,16 @@ class CurlClient implements ClientInterface
     /**
      * send request to the api server
      *
-     * @param $method
-     * @param $url
+     * @param string $method
+     * @param string $url
      * @param array $data
-     * @param $endpoint
-     * @param $credential
+     * @param string $endpoint
+     * @param AuthenticationInterface $credential
+     * @param boolean $isFile
+     * @param boolean $debug
      * @return array|string
-     * @throws Exception
+     * @throws \Exception
+     * @throws UnauthorizedException
      */
     public function sendRequest($method, $url, $data = array(), $endpoint, AuthenticationInterface $credential, $isFile = false, $debug = false)
     {


### PR DESCRIPTION
I was having problems with the createAttachment() using PHP 5.6. Turns out there is a new way to handle file uploads in Curl from PHP 5.5 and above: the function curl_file_create().

I also provided a way to specify the file name you want to use in Jira for the attachment you're uploading. It shouldn't break existing code, it's an optional parameter. If unused the filename defaults to basename() of the file you provide.

And I improved on some PHPDocs. Sorry, it's a fetish of mine...