### PR TITLE
Added an additional field of avatarId to IssueTypes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,11 @@
             "chobie\\" : "src"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "chobie\\Tests\\": "tests"
+        }
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "2.0-dev"

--- a/src/Jira/IssueType.php
+++ b/src/Jira/IssueType.php
@@ -85,4 +85,9 @@ class IssueType
     {
         return $this->iconUrl;
     }
+
+    public function getAvatarId()
+    {
+        return $this->avatarId;
+    }
 }

--- a/src/Jira/IssueType.php
+++ b/src/Jira/IssueType.php
@@ -38,6 +38,8 @@ class IssueType
 
     protected $subtask;
 
+    protected $avatarId;
+
     private $acceptable_keys = array(
         "self",
         "id",
@@ -45,6 +47,7 @@ class IssueType
         "iconUrl",
         "name",
         "subtask",
+        "avatarId",
     );
 
     public function __construct($types)

--- a/tests/Jira/IssueTypeTest.php
+++ b/tests/Jira/IssueTypeTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace chobie\Tests\Jira;
+
+use chobie\Jira\IssueType;
+
+class IssueTypeTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function testHandlesSingleIssueTypeWithAvatarId()
+    {
+        $issueTypeSource = array(
+        'self' => "https://hosted.atlassian.net/rest/api/2/issuetype/4",
+        'id' => "4",
+        'description' => "An improvement or enhancement to an existing feature or task.",
+        'iconUrl' => "https://hosted.atlassian.net/secure/viewavatar?size=xsmall&avatarId=1&avatarType=issuetype",
+        'name' => "Improvement",
+        'subtask' => false,
+        'avatarId' => 1
+        );
+        $issueType = new IssueType($issueTypeSource);
+        $this->assertEquals($issueType->getId(), $issueTypeSource['id']);
+        $this->assertEquals($issueType->getDescription(), $issueTypeSource['description']);
+        $this->assertEquals($issueType->getIconUrl(), $issueTypeSource['iconUrl']);
+        $this->assertEquals($issueType->getName(), $issueTypeSource['name']);
+        $this->assertEquals($issueType->getAvatarId(), $issueTypeSource['avatarId']);
+    }
+
+    public function testHandlesSingleIssueTypeWithoutAvatarId()
+    {
+        $issueTypeSource = array(
+            'self' => "https://hosted.atlassian.net/rest/api/2/issuetype/4",
+            'id' => "4",
+            'description' => "An improvement or enhancement to an existing feature or task.",
+            'iconUrl' => "https://hosted.atlassian.net/secure/viewavatar?size=xsmall&avatarId=1&avatarType=issuetype",
+            'name' => "Improvement",
+            'subtask' => false
+        );
+        $issueType = new IssueType($issueTypeSource);
+        $this->assertEquals($issueType->getId(), $issueTypeSource['id']);
+        $this->assertEquals($issueType->getDescription(), $issueTypeSource['description']);
+        $this->assertEquals($issueType->getIconUrl(), $issueTypeSource['iconUrl']);
+        $this->assertEquals($issueType->getName(), $issueTypeSource['name']);
+    }
+}


### PR DESCRIPTION
 Added an additional field of avatarId to IssueTypes as Jira Cloud is now returning this field via the api and causing the call to fail.

I've added a test to show this is now working.