### PR TITLE
Fix path in uploaded filename

### DIFF
--- a/src/Jira/Api.php
+++ b/src/Jira/Api.php
@@ -433,7 +433,7 @@ class Api
     {
         $options = array_merge(
             array(
-                "file" => '@' . $filename,
+                "file" => '@' . $filename . ';filename=' . pathinfo($filename, PATHINFO_BASENAME),
             ),
             $options
         );


### PR DESCRIPTION
if uploaded file located not in current directory it has sloppy name with path in JIRA: "/var/www/path/file.txt" instead of "file.txt"