### PR TITLE
Fix broken files upload on php > 5.6.0

### DIFF
--- a/src/Jira/Api/Client/CurlClient.php
+++ b/src/Jira/Api/Client/CurlClient.php
@@ -71,7 +71,9 @@ class CurlClient implements ClientInterface
         curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, 0);
         curl_setopt($curl, CURLOPT_VERBOSE, $debug);
         if ($isFile) {
-            curl_setopt($curl, CURLOPT_SAFE_UPLOAD, false);
+            if (defined('CURLOPT_SAFE_UPLOAD')) {
+                curl_setopt($curl, CURLOPT_SAFE_UPLOAD, false);
+            }
             curl_setopt($curl, CURLOPT_HTTPHEADER, array('X-Atlassian-Token: nocheck'));
         } else {
             curl_setopt($curl, CURLOPT_HTTPHEADER, array("Content-Type: application/json;charset=UTF-8"));

--- a/src/Jira/Api/Client/CurlClient.php
+++ b/src/Jira/Api/Client/CurlClient.php
@@ -71,6 +71,7 @@ class CurlClient implements ClientInterface
         curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, 0);
         curl_setopt($curl, CURLOPT_VERBOSE, $debug);
         if ($isFile) {
+            curl_setopt($curl, CURLOPT_SAFE_UPLOAD, false);
             curl_setopt($curl, CURLOPT_HTTPHEADER, array('X-Atlassian-Token: nocheck'));
         } else {
             curl_setopt($curl, CURLOPT_HTTPHEADER, array("Content-Type: application/json;charset=UTF-8"));
@@ -82,11 +83,9 @@ class CurlClient implements ClientInterface
             } else {
                 curl_setopt($curl, CURLOPT_POSTFIELDS, json_encode($data));
             }
-        } else {
-            if ($method == "PUT") {
-                curl_setopt($curl, CURLOPT_CUSTOMREQUEST, "PUT");
-                curl_setopt($curl, CURLOPT_POSTFIELDS, json_encode($data));
-            }
+        } elseif ($method == "PUT") {
+            curl_setopt($curl, CURLOPT_CUSTOMREQUEST, "PUT");
+            curl_setopt($curl, CURLOPT_POSTFIELDS, json_encode($data));
         }
 
         $data = curl_exec($curl);


### PR DESCRIPTION
CURLOPT_SAFE_UPLOAD - TRUE to disable support for the @ prefix for uploading files in CURLOPT_POSTFIELDS. 


Added in PHP 5.5.0 with FALSE as the default value. PHP 5.6.0 changes the default value to TRUE.

http://php.net/manual/ru/function.curl-setopt.php