### PR TITLE
Example wasn't working in namespaced class

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ composer require chobie/jira-api-restclient 2.0.*
 
 ````php
 <?php
-$api = new chobie\Jira\Api(
+$api = new \chobie\Jira\Api(
     "https://your-jira-project.net",
-    new chobie\Jira\Api\Authentication\Basic("yourname", "password")
+    new \chobie\Jira\Api\Authentication\Basic("yourname", "password")
 );
 
-$walker = new chobie\Jira\Issues\Walker($api);
+$walker = new \chobie\Jira\Issues\Walker($api);
 $walker->push("project = YOURPROJECT AND (status != closed and status != resolved) ORDER BY priority DESC");
 foreach ($walker as $issue) {
     var_dump($issue);


### PR DESCRIPTION
When I've copy-pasted example into another namespaced class method in my project nothing was working because of missing `\`.