### PR TITLE
Use basename for file uploads

### DIFF
--- a/src/Jira/Api/Client/PHPClient.php
+++ b/src/Jira/Api/Client/PHPClient.php
@@ -99,7 +99,7 @@ class PHPClient implements ClientInterface
                 $header[] = 'Content-Type: multipart/form-data; boundary=' . $boundary;
 
                 $__data = "--" . $boundary . "\r\n" .
-                    "Content-Disposition: form-data; name=\"file\"; filename=\"" . $filename . "\"\r\n" .
+                    "Content-Disposition: form-data; name=\"file\"; filename=\"" . basename($filename) . "\"\r\n" .
                     "Content-Type: application/octet-stream\r\n\r\n" .
                     file_get_contents($filename) . "\r\n";
                 $__data .= "--" . $boundary . "--\r\n";


### PR DESCRIPTION
There's a problem when using absolute paths for file uploads.

The upload seems to work fine, but then when you want to view the image in JIRA you get an error message:

```
Ouch! We can't load the image.

/secure/attachment/10909/%2Fvagrant%2Fweb%2Fattachments%2Fe7f29917-811e-41cd-8fed-6bd485e47afe.jpeg
```