### PR TITLE
Remove JIRA version information from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://secure.travis-ci.org/chobie/jira-api-restclient.png)](http://travis-ci.org/chobie/jira-api-restclient)
 
 
-you know JIRA5 supports REST API. this is very useful to make some custom notifications and automated jobs.
+you know JIRA supports REST API. this is very useful to make some custom notifications and automated jobs.
 (JIRA also supports email notification, but it's too much to custom templates, notification timing. unfortunately it requires Administration permission.)
 this API library will help your problems regarding JIRA. hope you enjoy it.
 
@@ -35,6 +35,6 @@ foreach ($walker as $issue) {
 
 MIT License
 
-# JIRA5 Rest API Documents
+# JIRA Rest API Documents
 
-https://developer.atlassian.com/static/rest/jira/6.0.html
+https://docs.atlassian.com/jira/REST/latest/


### PR DESCRIPTION
With JIRA releasing new versions very often it's hard to keep README updated with latest JIRA version and link API.

This change:

* removes JIRA version from README
* make API link always point to latest released JIRA version