### PR TITLE
Fixed typo in Api::getPriorities()

### DIFF
--- a/src/Jira/Api.php
+++ b/src/Jira/Api.php
@@ -296,22 +296,36 @@ class Api
     }
 
     /**
-     * get available priorities
+     * Get available priorities
      *
-     * @return mixed
+     * @return array
      */
     public function getPriorities()
     {
         if (!count($this->priorities)) {
             $priorities = array();
-            $result = $this->api(self::REQUEST_GET, "/rest/api/2/priority", array());
+            $result = $this->api(self::REQUEST_GET, '/rest/api/2/priority', array());
             /* set hash key as custom field id */
             foreach ($result->getResult() as $k => $v) {
                 $priorities[$v['id']] = $v;
             }
             $this->priorities = $priorities;
         }
+
         return $this->priorities;
+    }
+
+    /**
+     * Get available priorities
+     *
+     * @return array
+     * @deprecated Please use getPriorities()
+     */
+    public function getPriorties()
+    {
+        trigger_error('Use getPriorities() instead', E_USER_DEPRECATED);
+
+        return $this->getPriorities();
     }
 
     /**

--- a/src/Jira/Api.php
+++ b/src/Jira/Api.php
@@ -300,7 +300,7 @@ class Api
      *
      * @return mixed
      */
-    public function getPriorties()
+    public function getPriorities()
     {
         if (!count($this->priorities)) {
             $priorities = array();


### PR DESCRIPTION
Extension on #42 
- As by @aik099 comment, reinstated the old method name with a deprecation warning.