### PR TITLE
Added .idea to .gitignore to hide PHPStorm generated project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor
 composer.lock
+.idea


### PR DESCRIPTION
Since PHPStorm is the most widely used IDE it makes sense to add .idea to gitignore so the generated files don't clutter the git working copy.