### PR TITLE
Support for DELETE requests in the "CurlClient" class

### DIFF
--- a/src/Jira/Api/Client/CurlClient.php
+++ b/src/Jira/Api/Client/CurlClient.php
@@ -94,8 +94,8 @@ class CurlClient implements ClientInterface
             } else {
                 curl_setopt($curl, CURLOPT_POSTFIELDS, json_encode($data));
             }
-        } elseif ($method == 'PUT') {
-            curl_setopt($curl, CURLOPT_CUSTOMREQUEST, 'PUT');
+        } elseif ($method == 'PUT' || $method == 'DELETE') {
+            curl_setopt($curl, CURLOPT_CUSTOMREQUEST, $method);
             curl_setopt($curl, CURLOPT_POSTFIELDS, json_encode($data));
         }
 


### PR DESCRIPTION
The current CURL implementation does not acknowledge DELETE requests.  This fix allows for the HTTP DELETE verb to be used with the CURL wrapper.

However, all DELETE requests return "(bool) false" from within the "Api::api()" function call.  It appears that the Api class was not built really with DELETE calls in mind.  If the "Api::api()" function specifies how DELETE requests should return, I could also probably fix that as well.