### PR TITLE
Allows for "expand" option in search requests.

### DIFF
--- a/src/Jira/Api.php
+++ b/src/Jira/Api.php
@@ -440,10 +440,11 @@ class Api
      * @param int $startAt
      * @param int $maxResult
      * @param string $fields
+     * @param string $expand
      *
      * @return Result|false
      */
-    public function search($jql, $startAt = 0, $maxResult = 20, $fields = '*navigable')
+    public function search($jql, $startAt = 0, $maxResult = 20, $fields = '*navigable', $expand = null)
     {
         $result = $this->api(
             self::REQUEST_GET,
@@ -453,6 +454,7 @@ class Api
                 'startAt' => $startAt,
                 'maxResults' => $maxResult,
                 'fields' => $fields,
+                'expand' => $expand,
             )
         );
 


### PR DESCRIPTION
Since this utilizes NULL for the default, it should not create any BC breaks. Also, the underlying HTTP transmission code utilizes "http_build_query()" from PHP, and in this function array entries with NULL values are not included in the output. So, this change wouldn't even affect the URLs that are generated.