### PR TITLE
Fix uploaded attachment's filename

### DIFF
--- a/src/Jira/Api/Client/CurlClient.php
+++ b/src/Jira/Api/Client/CurlClient.php
@@ -133,9 +133,9 @@ class CurlClient implements ClientInterface
     protected function getCurlValue($fileString)
     {
         if (!function_exists('curl_file_create')) {
-            return $fileString;
+            return $fileString . '; filename=' . basename($fileString);
         }
 
-        return curl_file_create(substr($fileString, 1));
+        return curl_file_create(substr($fileString, 1), null, basename($fileString));
     }
 }


### PR DESCRIPTION
With the current implementation, an attachment you upload to JIRA gets the name of the full path you specified for the file upload location. 

In the example https://github.com/chobie/jira-api-restclient/blob/master/examples/create_attachement.php this problem cannot be seen because the sample uses a file to upload from the same folder using a relative path, but if you start using absolute paths, your attachments in JIRA will have very ugly and potentially long filenames - not to mention that it may expose file system information you probably don't want to leak.

This PR fixes that by setting the `; filename=` (pre-PHP 5.5) or the `postname` parameter of `\CURLFile` (PHP 5.5+) to just the file without any path info.