### PR TITLE
Removed incorrect typehint of $data in Api::api() which caused setWatchers to throw a warning

### DIFF
--- a/src/Jira/Api.php
+++ b/src/Jira/Api.php
@@ -691,7 +691,7 @@ class Api
 	public function api(
 		$method = self::REQUEST_GET,
 		$url,
-		array $data = array(),
+		$data = array(),
 		$return_as_json = false,
 		$is_file = false,
 		$debug = false

--- a/src/Jira/Api.php
+++ b/src/Jira/Api.php
@@ -681,7 +681,7 @@ class Api
 	 *
 	 * @param string  $method         Request method.
 	 * @param string  $url            URL.
-	 * @param array   $data           Data.
+	 * @param array|string   $data           Data.
 	 * @param boolean $return_as_json Return results as JSON.
 	 * @param boolean $is_file        Is file-related request.
 	 * @param boolean $debug          Debug this request.

--- a/src/Jira/Api.php
+++ b/src/Jira/Api.php
@@ -679,12 +679,12 @@ class Api
 	/**
 	 * Send request to specified host.
 	 *
-	 * @param string  $method         Request method.
-	 * @param string  $url            URL.
-	 * @param array|string   $data           Data.
-	 * @param boolean $return_as_json Return results as JSON.
-	 * @param boolean $is_file        Is file-related request.
-	 * @param boolean $debug          Debug this request.
+	 * @param string       $method         Request method.
+	 * @param string       $url            URL.
+	 * @param array|string $data           Data.
+	 * @param boolean      $return_as_json Return results as JSON.
+	 * @param boolean      $is_file        Is file-related request.
+	 * @param boolean      $debug          Debug this request.
 	 *
 	 * @return array|Result|false
 	 */

--- a/src/Jira/Api/Client/ClientInterface.php
+++ b/src/Jira/Api/Client/ClientInterface.php
@@ -35,7 +35,7 @@ interface ClientInterface
 	 *
 	 * @param string                  $method     Request method.
 	 * @param string                  $url        URL.
-	 * @param array                   $data       Request data.
+	 * @param array|string            $data       Request data.
 	 * @param string                  $endpoint   Endpoint.
 	 * @param AuthenticationInterface $credential Credential.
 	 * @param boolean                 $is_file    This is a file upload request.

--- a/src/Jira/Api/Client/CurlClient.php
+++ b/src/Jira/Api/Client/CurlClient.php
@@ -46,7 +46,7 @@ class CurlClient implements ClientInterface
 	 *
 	 * @param string                  $method     Request method.
 	 * @param string                  $url        URL.
-	 * @param array                   $data       Request data.
+	 * @param array|string            $data       Request data.
 	 * @param string                  $endpoint   Endpoint.
 	 * @param AuthenticationInterface $credential Credential.
 	 * @param boolean                 $is_file    This is a file upload request.
@@ -75,6 +75,10 @@ class CurlClient implements ClientInterface
 
 		if ( $method == 'GET' ) {
 			$url .= '?' . http_build_query($data);
+
+			if ( !is_array($data) ) {
+				throw new \InvalidArgumentException('Data must be an array.');
+			}
 		}
 
 		curl_setopt($curl, CURLOPT_URL, $endpoint . $url);

--- a/src/Jira/Api/Client/CurlClient.php
+++ b/src/Jira/Api/Client/CurlClient.php
@@ -57,6 +57,7 @@ class CurlClient implements ClientInterface
 	 * @throws Exception When request failed due CURL error.
 	 * @throws UnauthorizedException When request failed, because user can't be authorized properly.
 	 * @throws Exception When there was empty response instead of needed data.
+	 * @throws \InvalidArgumentException When data is not an array and http method is GET.
 	 */
 	public function sendRequest(
 		$method,

--- a/src/Jira/Api/Client/PHPClient.php
+++ b/src/Jira/Api/Client/PHPClient.php
@@ -68,7 +68,7 @@ class PHPClient implements ClientInterface
 	 *
 	 * @param string                  $method     Request method.
 	 * @param string                  $url        URL.
-	 * @param array                   $data       Request data.
+	 * @param array|string            $data       Request data.
 	 * @param string                  $endpoint   Endpoint.
 	 * @param AuthenticationInterface $credential Credential.
 	 * @param boolean                 $is_file    This is a file upload request.


### PR DESCRIPTION
setWatchers Method pass a String as Data for the api call and not an array. This produces an warning that crash some applications.

PHP Error:

PHP Catchable fatal error:  Argument 3 passed to chobie\Jira\Api::api() must be an array, string given