### PR TITLE
Maximal test coverage for "ClientInterface" implementing classes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,19 @@ php:
   - hhvm
   - 7.0
 
+matrix:
+  allow_failures:
+    - php: hhvm
+
 install:
   - composer install --prefer-dist
 
+before_script:
+  - ~/.phpenv/versions/5.6/bin/php -S localhost:8000 -t $(pwd) > /dev/null 2> /tmp/webserver_output.txt &
+  - export REPO_URL=http://localhost:8000/
+
 script:
   - ./vendor/bin/phpunit
+
+after_failure:
+    - cat /tmp/webserver_output.txt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,15 @@ JIRA REST API Client is an open source, community-driven project. If you'd like 
 7. Create Pull Request.
 
 ## Running the Tests
+
+To be able to run integration tests locally (optional) please follow these steps once:
+
+1. make sure repository is located in web server document root (or it's sub-folder)
+2. copy `phpunit.xml.dist` file into `phpunit.xml` file
+3. in the `phpunit.xml` file:
+ * uncomment part, where `REPO_URL` environment variable is defined
+ * set `REPO_URL` environment variable value to URL, from where repository can be accessed (e.g. `http://localhost/path/to/repository/`)
+
 Make sure that you don't break anything with your changes by running:
 
 ```bash

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<phpunit backupGlobals="true"
+<phpunit bootstrap="vendor/autoload.php"
+         backupGlobals="true"
          backupStaticAttributes="false"
          colors="true"
          convertErrorsToExceptions="true"
@@ -13,13 +14,17 @@
          syntaxCheck="true"
          strict="true"
          verbose="true">
-    <php>
-        <ini name="date.timezone" value="Asia/Tokyo" />
-    </php>
+
     <testsuites>
         <testsuite name="Jira_Api Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
+
+    <!--
+        <php>
+            <server name="REPO_URL" value="http://localhost/"/>
+        </php>
+    -->
 
 </phpunit>

--- a/src/Jira/Api/Client/ClientInterface.php
+++ b/src/Jira/Api/Client/ClientInterface.php
@@ -26,6 +26,8 @@ namespace chobie\Jira\Api\Client;
 
 
 use chobie\Jira\Api\Authentication\AuthenticationInterface;
+use chobie\Jira\Api\Exception;
+use chobie\Jira\Api\UnauthorizedException;
 
 interface ClientInterface
 {
@@ -42,6 +44,11 @@ interface ClientInterface
 	 * @param boolean                 $debug      Debug this request.
 	 *
 	 * @return array|string
+	 * @throws \InvalidArgumentException When non-supported implementation of AuthenticationInterface is given.
+	 * @throws \InvalidArgumentException When data is not an array and http method is GET.
+	 * @throws Exception When request failed due communication error.
+	 * @throws UnauthorizedException When request failed, because user can't be authorized properly.
+	 * @throws Exception When there was empty response instead of needed data.
 	 */
 	public function sendRequest(
 		$method,

--- a/tests/Jira/Api/Client/AbstractClientTestCase.php
+++ b/tests/Jira/Api/Client/AbstractClientTestCase.php
@@ -1,0 +1,280 @@
+<?php
+
+namespace Tests\chobie\Jira\Api\Client;
+
+
+use chobie\Jira\Api;
+use chobie\Jira\Api\Authentication\Anonymous;
+use chobie\Jira\Api\Authentication\AuthenticationInterface;
+use chobie\Jira\Api\Authentication\Basic;
+use chobie\Jira\Api\Client\ClientInterface;
+
+abstract class AbstractClientTestCase extends \PHPUnit_Framework_TestCase
+{
+
+	/**
+	 * Client.
+	 *
+	 * @var ClientInterface
+	 */
+	protected $client;
+
+	protected function setUp()
+	{
+		parent::setUp();
+
+		if ( empty($_SERVER['REPO_URL']) ) {
+			$this->markTestSkipped('The "REPO_URL" environment variable not set.');
+		}
+
+		$this->client = $this->createClient();
+	}
+
+	public function testGetRequest()
+	{
+		$data = array('param1' => 'value1', 'param2' => 'value2');
+		$trace_result = $this->traceRequest(Api::REQUEST_GET, $data);
+
+		$this->assertEquals('GET', $trace_result['_SERVER']['REQUEST_METHOD']);
+		$this->assertContentType('application/json;charset=UTF-8', $trace_result);
+		$this->assertEquals($data, $trace_result['_GET']);
+	}
+
+	/**
+	 * @expectedException \InvalidArgumentException
+	 * @expectedExceptionMessage Data must be an array.
+	 */
+	public function testGetRequestError()
+	{
+		$this->traceRequest(Api::REQUEST_GET, 'param1=value1&param2=value2');
+	}
+
+	public function testPostRequest()
+	{
+		$data = array('param1' => 'value1', 'param2' => 'value2');
+		$trace_result = $this->traceRequest(Api::REQUEST_POST, $data);
+
+		$this->assertEquals('POST', $trace_result['_SERVER']['REQUEST_METHOD']);
+		$this->assertContentType('application/json;charset=UTF-8', $trace_result);
+		$this->assertEquals(json_encode($data), $trace_result['INPUT']);
+	}
+
+	public function testPutRequest()
+	{
+		$data = array('param1' => 'value1', 'param2' => 'value2');
+		$trace_result = $this->traceRequest(Api::REQUEST_PUT, $data);
+
+		$this->assertEquals('PUT', $trace_result['_SERVER']['REQUEST_METHOD']);
+		$this->assertContentType('application/json;charset=UTF-8', $trace_result);
+		$this->assertEquals(json_encode($data), $trace_result['INPUT']);
+	}
+
+	public function testDeleteRequest()
+	{
+		$data = array('param1' => 'value1', 'param2' => 'value2');
+		$trace_result = $this->traceRequest(Api::REQUEST_DELETE, $data);
+
+		$this->assertEquals('DELETE', $trace_result['_SERVER']['REQUEST_METHOD']);
+		$this->assertContentType('application/json;charset=UTF-8', $trace_result);
+		$this->assertEquals(json_encode($data), $trace_result['INPUT']);
+	}
+
+	public function testFileUpload()
+	{
+		$upload_file = __FILE__;
+		$trace_result = $this->traceRequest(Api::REQUEST_POST, array('file' => '@' . $upload_file), null, true);
+
+		$this->assertEquals('POST', $trace_result['_SERVER']['REQUEST_METHOD']);
+
+		$this->assertArrayHasKey('HTTP_X_ATLASSIAN_TOKEN', $trace_result['_SERVER']);
+		$this->assertEquals('nocheck', $trace_result['_SERVER']['HTTP_X_ATLASSIAN_TOKEN']);
+
+		$this->assertCount(
+			1,
+			$trace_result['_FILES'],
+			'File was uploaded'
+		);
+		$this->assertArrayHasKey(
+			'file',
+			$trace_result['_FILES'],
+			'File was uploaded under "file" field name'
+		);
+		$this->assertEquals(
+			basename($upload_file),
+			$trace_result['_FILES']['file']['name'],
+			'Basename is used as filename'
+		);
+		$this->assertNotEmpty($trace_result['_FILES']['file']['type']);
+		$this->assertEquals(
+			UPLOAD_ERR_OK,
+			$trace_result['_FILES']['file']['error'],
+			'No upload error happened'
+		);
+		$this->assertGreaterThan(
+			0,
+			$trace_result['_FILES']['file']['size'],
+			'File is not empty'
+		);
+	}
+
+	public function testUnsupportedCredentialGiven()
+	{
+		$client_class_parts = explode('\\', get_class($this->client));
+		$credential = $this->prophesize('chobie\Jira\Api\Authentication\AuthenticationInterface')->reveal();
+
+		$this->setExpectedException(
+			'InvalidArgumentException',
+			end($client_class_parts) . ' does not support ' . get_class($credential) . ' authentication.'
+		);
+
+		$this->client->sendRequest(Api::REQUEST_GET, 'url', array(), 'endpoint', $credential);
+	}
+
+	public function testBasicCredentialGiven()
+	{
+		$credential = new Basic('user1', 'pass1');
+
+		$trace_result = $this->traceRequest(Api::REQUEST_GET, array(), $credential);
+
+		$this->assertArrayHasKey('PHP_AUTH_USER', $trace_result['_SERVER']);
+		$this->assertEquals('user1', $trace_result['_SERVER']['PHP_AUTH_USER']);
+
+		$this->assertArrayHasKey('PHP_AUTH_PW', $trace_result['_SERVER']);
+		$this->assertEquals('pass1', $trace_result['_SERVER']['PHP_AUTH_PW']);
+	}
+
+	public function testCommunicationError()
+	{
+		$this->markTestIncomplete('TODO');
+	}
+
+	/**
+	 * @expectedException \chobie\Jira\Api\UnauthorizedException
+	 * @expectedExceptionMessage Unauthorized
+	 */
+	public function testUnauthorizedRequest()
+	{
+		$this->traceRequest(Api::REQUEST_GET, array('http_code' => 401));
+	}
+
+	/**
+	 * @expectedException \chobie\Jira\Api\Exception
+	 * @expectedExceptionMessage JIRA Rest server returns unexpected result.
+	 */
+	public function testEmptyResponseWithUnknownHttpCode()
+	{
+		$this->traceRequest(Api::REQUEST_GET, array('response_mode' => 'empty'));
+	}
+
+	/**
+	 * @dataProvider emptyResponseWithKnownHttpCodeDataProvider
+	 */
+	public function testEmptyResponseWithKnownHttpCode($http_code)
+	{
+		$this->assertSame(
+			'',
+			$this->traceRequest(Api::REQUEST_GET, array('http_code' => $http_code, 'response_mode' => 'empty'))
+		);
+	}
+
+	public function emptyResponseWithKnownHttpCodeDataProvider()
+	{
+		return array(
+			'http 201' => array(201),
+			'http 204' => array(204),
+		);
+	}
+
+	/**
+	 * Checks, that request contained specified content type.
+	 *
+	 * @param string $expected     Expected.
+	 * @param array  $trace_result Trace result.
+	 *
+	 * @return void
+	 */
+	protected function assertContentType($expected, array $trace_result)
+	{
+		if ( array_key_exists('CONTENT_TYPE', $trace_result['_SERVER']) ) {
+			// Normal Web Server.
+			$content_type = $trace_result['_SERVER']['CONTENT_TYPE'];
+		}
+		elseif ( array_key_exists('HTTP_CONTENT_TYPE', $trace_result['_SERVER']) ) {
+			// PHP Built-In Web Server.
+			$content_type = $trace_result['_SERVER']['HTTP_CONTENT_TYPE'];
+		}
+		else {
+			$content_type = null;
+		}
+
+		$this->assertEquals($expected, $content_type, 'Content type is correct');
+	}
+
+	/**
+	 * Traces a request.
+	 *
+	 * @param string                        $method     Request method.
+	 * @param array                         $data       Request data.
+	 * @param  AuthenticationInterface|null $credential Credential.
+	 * @param boolean                       $is_file    This is a file upload request.
+	 *
+	 * @return array
+	 */
+	protected function traceRequest(
+		$method,
+		$data = array(),
+		AuthenticationInterface $credential = null,
+		$is_file = false
+	) {
+		if ( !isset($credential) ) {
+			$credential = new Anonymous();
+		}
+
+		$path_info_variables = array(
+			'http_code' => 200,
+			'response_mode' => 'trace',
+		);
+
+		if ( is_array($data) ) {
+			if ( isset($data['http_code']) ) {
+				$path_info_variables['http_code'] = $data['http_code'];
+				unset($data['http_code']);
+			}
+
+			if ( isset($data['response_mode']) ) {
+				$path_info_variables['response_mode'] = $data['response_mode'];
+				unset($data['response_mode']);
+			}
+		}
+
+		$path_info = array();
+
+		foreach ( $path_info_variables as $variable_name => $variable_value ) {
+			$path_info[] = $variable_name;
+			$path_info[] = $variable_value;
+		}
+
+		$result = $this->client->sendRequest(
+			$method,
+			'/tests/debug_response.php/' . implode('/', $path_info) . '/',
+			$data,
+			rtrim($_SERVER['REPO_URL'], '/'),
+			$credential,
+			$is_file
+		);
+
+		if ( $path_info_variables['response_mode'] === 'trace' ) {
+			return unserialize($result);
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Creates client.
+	 *
+	 * @return ClientInterface
+	 */
+	abstract protected function createClient();
+
+}

--- a/tests/Jira/Api/Client/CurlClientTest.php
+++ b/tests/Jira/Api/Client/CurlClientTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\chobie\Jira\Api\Client;
+
+
+use chobie\Jira\Api\Client\ClientInterface;
+use chobie\Jira\Api\Client\CurlClient;
+
+class CurlClientTest extends AbstractClientTestCase
+{
+
+	/**
+	 * Creates client.
+	 *
+	 * @return ClientInterface
+	 */
+	protected function createClient()
+	{
+		return new CurlClient();
+	}
+
+}

--- a/tests/Jira/Api/Client/PHPClientTest.php
+++ b/tests/Jira/Api/Client/PHPClientTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\chobie\Jira\Api\Client;
+
+
+use chobie\Jira\Api\Client\ClientInterface;
+use chobie\Jira\Api\Client\PHPClient;
+
+class PHPClientTest extends AbstractClientTestCase
+{
+
+	/**
+	 * Creates client.
+	 *
+	 * @return ClientInterface
+	 */
+	protected function createClient()
+	{
+		return new PHPClient();
+	}
+
+}

--- a/tests/debug_response.php
+++ b/tests/debug_response.php
@@ -1,0 +1,57 @@
+<?php
+
+$result = array(
+	'_SERVER' => $_SERVER,
+	'_GET' => $_GET,
+	'_POST' => $_POST,
+	'_COOKIE' => $_COOKIE,
+	'_FILES' => $_FILES,
+	'INPUT' => file_get_contents('php://input'),
+);
+
+$path_info_variables = array();
+$path_info = explode('/', trim($_SERVER['PATH_INFO'], '/'));
+
+while ( $path_info ) {
+	$variable_name = array_shift($path_info);
+	$variable_value = array_shift($path_info);
+
+	$path_info_variables[$variable_name] = $variable_value;
+}
+
+if ( array_key_exists('http_code', $path_info_variables) ) {
+	// Complete code list: https://developer.mozilla.org/en-US/docs/Web/HTTP/Response_codes.
+	$http_code_messages = array(
+		200 => 'OK',
+		201 => 'Created',
+		204 => 'No Content',
+		400 => 'Bad Request',
+		401 => 'Unauthorized',
+		403 => 'Forbidden',
+		404 => 'Not Found',
+	);
+
+	$http_code = (int)$path_info_variables['http_code'];
+
+	if ( $http_code !== 200 ) {
+		header('HTTP/1.1 ' . $http_code . ' ' . $http_code_messages[$http_code]);
+	}
+}
+
+if ( array_key_exists('response_mode', $path_info_variables) ) {
+	$response_mode = $path_info_variables['response_mode'];
+}
+else {
+	$response_mode = 'trace';
+}
+
+if ( $response_mode === 'trace' ) {
+	echo serialize($result);
+}
+elseif ( $response_mode === 'empty' ) {
+	echo '';
+}
+elseif ( $response_mode === 'null' ) {
+	echo null;
+}
+


### PR DESCRIPTION
Problems solved:

* check check for non-array `$data` parameter during `GET` request value in `CurlClient` class was made after it was passed into `http_build_query` function call and that caused a notice
* no check was made for `$data` being an array during `GET` request in `PHPClient`
* the `PHPClient` wasn't sending correct `Content-Type` header, when making `GET` request
* support for `DELETE` calls in `PHPClient`
* file uploads via `CurlClient` were not working in PHP < 5.5 and HHVM (regression introduced in 96ab84e74ca8472ce8d88673742fe39230ccefeb)
* file uploads via `CurlClient` were not working in PHP > 7.0 (regression introduced in 048d96d2052f92d70ea025bc6bbe0e121337d399)
* the `PHPClient` was throwing different exceptions, then `CurlClient` for same HTTP responses

Problems not solved:

* `PHPClient` test that is getting HTTP 201 and HTTP 204 responses on HHVM 3.6.6 (Travis CI version) is failing for unknown reason. Locally I've tried on HHVM 3.13.1 and it works. I'm guessing this is HHVM bug.
* Not sure how to write test that would emulate communication error.
* Not sure how to write where test was no communication error, but somehow response is NULL.

Also related to #100.