### PR TITLE
Use Prophecy for mocking in "Api" class tests

### DIFF
--- a/src/Jira/Api.php
+++ b/src/Jira/Api.php
@@ -426,7 +426,7 @@ class Api
 	 * @param string $project_key Project Key.
 	 * @param string $name        The version name to match on.
 	 *
-	 * @return integer|null VersionId on match or null when there is no match.
+	 * @return array|null Version data on match or null when there is no match.
 	 * @since  2.0.0
 	 */
 	public function findVersionByName($project_key, $name)
@@ -592,7 +592,7 @@ class Api
 	 * @param integer $version_id Version ID.
 	 * @param array   $params     Key->Value list to update the version with.
 	 *
-	 * @return Result|false
+	 * @return false
 	 * @since  2.0.0
 	 * @link   https://docs.atlassian.com/jira/REST/latest/#api/2/version-updateVersion
 	 */
@@ -608,7 +608,7 @@ class Api
 	 * @param string|null $release_date Date in Y-m-d format (defaults to today).
 	 * @param array       $params       Optionally extra parameters.
 	 *
-	 * @return Result|false
+	 * @return false
 	 * @since  2.0.0
 	 */
 	public function releaseVersion($version_id, $release_date = null, array $params = array())
@@ -858,7 +858,7 @@ class Api
 	{
 		return $this->api(self::REQUEST_GET, sprintf('/rest/api/2/project/%s/components', $project_key), array(), true);
 	}
-        
+
 	/**
 	 * Get all issue types with valid status values for a project.
 	 *
@@ -867,11 +867,11 @@ class Api
 	 * @return array
 	 * @since  2.0.0
 	 */
-	public function getProjectIssueTypes($project_key) 
+	public function getProjectIssueTypes($project_key)
 	{
 		return $this->api(self::REQUEST_GET, sprintf('/rest/api/2/project/%s/statuses', $project_key), array(), true);
 	}
-        
+
 	/**
 	 * Returns a list of all resolutions.
 	 *
@@ -880,7 +880,7 @@ class Api
 	 * @return array|false
 	 * @since  2.0.0
 	 */
-	public function getResolutions() 
+	public function getResolutions()
 	{
 		return $this->api(self::REQUEST_GET, '/rest/api/2/resolution', array(), true);
 	}

--- a/tests/Jira/ApiTest.php
+++ b/tests/Jira/ApiTest.php
@@ -4,7 +4,8 @@ namespace Tests\chobie\Jira;
 
 
 use chobie\Jira\Api;
-use chobie\Jira\Api\Authentication\Anonymous;
+use chobie\Jira\Api\Authentication\AuthenticationInterface;
+use Prophecy\Prophecy\ObjectProphecy;
 
 /**
  * Class ApiTest
@@ -14,116 +15,164 @@ use chobie\Jira\Api\Authentication\Anonymous;
 class ApiTest extends \PHPUnit_Framework_TestCase
 {
 
-	/**
-	 * Tests that any trailing slash in the endpoint url is removed before being stored in the object state
-	 */
-	public function testSetEndpointTrailingSlash()
-	{
-		$api = new Api('https://test.test/', new Anonymous(), null);
-		$this->assertEquals('https://test.test', $api->getEndpoint());
+	const ENDPOINT = 'http://jira.company.com';
 
-		// Make sure nothing is removed if there is no trailing slash
-		$url = 'https://urlwithouttrailing.slash';
-		$api->setEndPoint($url);
-		$this->assertEquals($url, $api->getEndpoint());
+	/**
+	 * Api.
+	 *
+	 * @var Api
+	 */
+	protected $api;
+
+	/**
+	 * Credential.
+	 *
+	 * @var AuthenticationInterface
+	 */
+	protected $credential;
+
+	/**
+	 * Client.
+	 *
+	 * @var ObjectProphecy
+	 */
+	protected $client;
+
+	protected function setUp()
+	{
+		parent::setUp();
+
+		$this->credential = $this->prophesize('chobie\Jira\Api\Authentication\AuthenticationInterface')->reveal();
+		$this->client = $this->prophesize('chobie\Jira\Api\Client\ClientInterface');
+
+		$this->api = new Api(self::ENDPOINT, $this->credential, $this->client->reveal());
 	}
 
 	/**
-	 * Tests that the updateVersion call constructs the correct api call
+	 * @dataProvider setEndpointDataProvider
 	 */
+	public function testSetEndpoint($given_endpoint, $used_endpoint)
+	{
+		$api = new Api($given_endpoint, $this->credential, $this->client->reveal());
+		$this->assertEquals($used_endpoint, $api->getEndpoint());
+	}
+
+	public function setEndpointDataProvider()
+	{
+		return array(
+			'trailing slash removed' => array('https://test.test/', 'https://test.test'),
+			'nothing removed' => array('https://test.test', 'https://test.test'),
+		);
+	}
+
 	public function testUpdateVersion()
 	{
 		$params = array(
-			'released' => true,
-			'releaseDate' => '2010-07-06',
+			'overdue' => true,
+			'description' => 'new description',
 		);
 
-		// Stub the api method and keep the rest intact
-		/** @var Api|\PHPUnit_Framework_MockObject_MockObject $api */
-		$api = $this->getMockBuilder('\chobie\Jira\Api')->setMethods(array('api'))->disableOriginalConstructor()->getMock();
-		$api->expects($this->once())->method('api')->with(
-			$this->equalTo(Api::REQUEST_PUT),
-			$this->equalTo('/rest/api/2/version/111000'),
-			$this->equalTo($params)
+		$this->expectClientCall(
+			Api::REQUEST_PUT,
+			'/rest/api/2/version/111000',
+			$params,
+			''
 		);
 
-		$api->updateVersion(111000, $params);
+		$this->assertFalse($this->api->updateVersion(111000, $params));
 	}
 
-	/**
-	 * Tests that the releaseVersion call constructs the correct api call
-	 */
-	public function testReleaseVersion()
+	public function testReleaseVersionAutomaticReleaseDate()
 	{
 		$params = array(
 			'released' => true,
 			'releaseDate' => date('Y-m-d'),
 		);
 
-		// Stub the api method and keep the rest intact
-		/** @var Api|\PHPUnit_Framework_MockObject_MockObject $api */
-		$api = $this->getMockBuilder('\chobie\Jira\Api')->setMethods(array('api'))->disableOriginalConstructor()->getMock();
-		$api->expects($this->once())->method('api')->with(
-			$this->equalTo(Api::REQUEST_PUT),
-			$this->equalTo('/rest/api/2/version/111000'),
-			$this->equalTo($params)
+		$this->expectClientCall(
+			Api::REQUEST_PUT,
+			'/rest/api/2/version/111000',
+			$params,
+			''
 		);
 
-		$api->releaseVersion(111000);
+		$this->assertFalse($this->api->releaseVersion(111000));
 	}
 
-	/**
-	 * Tests that the releaseVersion call constructs the correct api call with overriden release data and params
-	 */
-	public function testReleaseVersionAdvanced()
+	public function testReleaseVersionParameterMerging()
 	{
-		$releaseDate = '2010-07-06';
+		$release_date = '2010-07-06';
 
-		$params = array(
+		$expected_params = array(
 			'released' => true,
-			'releaseDate' => $releaseDate,
+			'releaseDate' => $release_date,
 			'test' => 'extra',
 		);
 
-		// Stub the api method and keep the rest intact
-		/** @var Api|\PHPUnit_Framework_MockObject_MockObject $api */
-		$api = $this->getMockBuilder('\chobie\Jira\Api')->setMethods(array('api'))->disableOriginalConstructor()->getMock();
-		$api->expects($this->once())->method('api')->with(
-			$this->equalTo(Api::REQUEST_PUT),
-			$this->equalTo('/rest/api/2/version/111000'),
-			$this->equalTo($params)
+		$this->expectClientCall(
+			Api::REQUEST_PUT,
+			'/rest/api/2/version/111000',
+			$expected_params,
+			''
 		);
 
-		$api->releaseVersion(111000, $releaseDate, array('test' => 'extra'));
+		$this->assertFalse($this->api->releaseVersion(111000, $release_date, array('test' => 'extra')));
 	}
 
-	/**
-	 * Tests FindVersionByName
-	 */
 	public function testFindVersionByName()
 	{
-		$name = '3.36.0';
-		$versionId = '14206';
-		$projectKey = 'POR';
+		$project_key = 'POR';
+		$version_id = '14206';
+		$version_name = '3.36.0';
 
 		$versions = array(
 			array('id' => '14205', 'name' => '3.62.0'),
-			array('id' => $versionId, 'name' => $name),
+			array('id' => $version_id, 'name' => $version_name),
 			array('id' => '14207', 'name' => '3.66.0'),
 		);
 
-		// Stub the getVersions method and keep the rest intact
-		/** @var Api|\PHPUnit_Framework_MockObject_MockObject $api */
-		$api = $this->getMockBuilder('\chobie\Jira\Api')->setMethods(array('getVersions'))->disableOriginalConstructor()->getMock();
-		$api->expects($this->exactly(2))->method('getVersions')->with(
-			$this->equalTo($projectKey)
-		)->willReturn($versions);
+		$this->expectClientCall(
+			Api::REQUEST_GET,
+			'/rest/api/2/project/' . $project_key . '/versions',
+			array(),
+			json_encode($versions)
+		);
 
-		// He should find this one
-		$this->assertEquals(array('id' => $versionId, 'name' => $name), $api->findVersionByName($projectKey, $name));
+		$this->assertEquals(
+			array('id' => $version_id, 'name' => $version_name),
+			$this->api->findVersionByName($project_key, $version_name),
+			'Version found'
+		);
 
-		// And there should be no result for this one
-		$this->assertNull($api->findVersionByName($projectKey, 'i_do_not_exist'));
+		$this->assertNull(
+			$this->api->findVersionByName($project_key, 'i_do_not_exist')
+		);
+	}
+
+	/**
+	 * Expects a particular client call.
+	 *
+	 * @param string       $method       Request method.
+	 * @param string       $url          URL.
+	 * @param array|string $data         Request data.
+	 * @param string       $return_value Return value.
+	 * @param boolean      $is_file      This is a file upload request.
+	 * @param boolean      $debug        Debug this request.
+	 *
+	 * @return void
+	 */
+	protected function expectClientCall(
+		$method,
+		$url,
+		$data = array(),
+		$return_value,
+		$is_file = false,
+		$debug = false
+	) {
+		$this->client
+			->sendRequest($method, $url, $data, self::ENDPOINT, $this->credential, $is_file, $debug)
+			->willReturn($return_value)
+			->shouldBeCalled();
 	}
 
 }


### PR DESCRIPTION
Problems solved:

* the DocBlock of `updateVersion` and `releaseVersion` methods were saying that they return `Result`, but they never do
* the DocBlock of `findVersionByName` method was saying that it returns VersionId, but it actually returns all version fields
* tests for `Api` class were mocking `Api` class partially and that is considered as bad practice (changed to mock client class instead)
* several assertions per test were replaced with data provider usage (where appropriate)
* removed DocBlocks of test methods in favor of improved test names themselves
* added helper methods to be used for quick test writing for all other methods of `Api` class

P.S.
My apologies for 3 places, where PhpStorm removed trailing whitespaces. Not sure if it's worth redoing PR to exclude them.