### PR TITLE
Installation command in README resulted in error

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ foreach ( $walker as $issue ) {
 ## Installation
 
 ```
-php composer.phar require chobie/jira-api-restclient 2.0@dev
+php composer.phar require chobie/jira-api-restclient ^2.0@dev
 ```
 
 ## Requirements


### PR DESCRIPTION
Without `^` in front of version attempt to use composer command from README results in following error:

```
Loading composer repositories with package information
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - The requested package chobie/jira-api-restclient 2.0.0@dev exists as chobie/jira-api-restclient[dev-master, 2.0.x-dev, v1.0.0] but these are rejected by your constraint.
```

Closes #127 