### PR TITLE
Removed deprecated Api::getPriorties()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Classes/interfaces were renamed to use namespaces by [@chobie].
 - Using PSR-4 autoloader from Composer by [@chobie].
 - Minimal supported PHP version changed from 5.2 to 5.3 by [@chobie].
-- The `Api::getPriorties` renamed into `Api::getPriorities` (former method kept for BC reasons) by [@josevh].
+- The `Api::getPriorties` renamed into `Api::getPriorities` by [@josevh].
 - Remove trailing slash from endpoint url by [@Procta].
 
 ### Removed

--- a/src/Jira/Api.php
+++ b/src/Jira/Api.php
@@ -472,19 +472,6 @@ class Api
 	}
 
 	/**
-	 * Get available priorities.
-	 *
-	 * @return     array
-	 * @deprecated Please use getPriorities()
-	 */
-	public function getPriorties()
-	{
-		trigger_error('Use getPriorities() instead', E_USER_DEPRECATED);
-
-		return $this->getPriorities();
-	}
-
-	/**
 	 * Get available statuses.
 	 *
 	 * @return array


### PR DESCRIPTION
Fixes #124. (Method has been deprecated since 28 feb 2016) 