### PR TITLE
Renamed Api::api() parameter $return_as_json to $return_as_array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - The `Api::getPriorties` renamed into `Api::getPriorities` by [@josevh].
 - Remove trailing slash from endpoint url by [@Procta].
 - Added local cache to getResolutions [@jpastoor].
+- Renamed Api::api() parameter $return_as_json to $return_as_array [@jpastoor].
 
 ### Removed
 ...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Minimal supported PHP version changed from 5.2 to 5.3 by [@chobie].
 - The `Api::getPriorties` renamed into `Api::getPriorities` by [@josevh].
 - Remove trailing slash from endpoint url by [@Procta].
-- Added local cache to getResolutions [@jpastoor].
-- Renamed Api::api() parameter $return_as_json to $return_as_array [@jpastoor].
+- Added local cache to getResolutions by [@jpastoor].
+- Renamed Api::api() parameter $return_as_json to $return_as_array by [@jpastoor].
 
 ### Removed
 ...
@@ -36,7 +36,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed PHP deprecation notice, when creating issue attachments via `CurlClient` on PHP 5.5+ by [@DerMika].
 - The `Api::getRoles` call was always retuning an error by [@aik099].
 - Attempt to make a `DELETE` API call using `CurlClient` wasn't working by [@aik099].
-- Clearing local caches (statuses, priorities, fields and resolutions) on endpoint change [@jpastoor].
+- Clearing local caches (statuses, priorities, fields and resolutions) on endpoint change by [@jpastoor].
 
 ## [1.0.0] - 2014-07-27
 ### Added

--- a/src/Jira/Api.php
+++ b/src/Jira/Api.php
@@ -704,7 +704,7 @@ class Api
 	 * @param string       $method         Request method.
 	 * @param string       $url            URL.
 	 * @param array|string $data           Data.
-	 * @param boolean      $return_as_json Return results as JSON.
+	 * @param boolean      $return_as_array Return results as JSON.
 	 * @param boolean      $is_file        Is file-related request.
 	 * @param boolean      $debug          Debug this request.
 	 *
@@ -714,7 +714,7 @@ class Api
 		$method = self::REQUEST_GET,
 		$url,
 		$data = array(),
-		$return_as_json = false,
+		$return_as_array = false,
 		$is_file = false,
 		$debug = false
 	) {
@@ -743,7 +743,7 @@ class Api
 				}
 			}
 
-			if ( $return_as_json ) {
+			if ( $return_as_array ) {
 				return $json;
 			}
 			else {

--- a/src/Jira/Api.php
+++ b/src/Jira/Api.php
@@ -701,12 +701,12 @@ class Api
 	/**
 	 * Send request to specified host.
 	 *
-	 * @param string       $method         Request method.
-	 * @param string       $url            URL.
-	 * @param array|string $data           Data.
-	 * @param boolean      $return_as_array Return results as JSON.
-	 * @param boolean      $is_file        Is file-related request.
-	 * @param boolean      $debug          Debug this request.
+	 * @param string       $method          Request method.
+	 * @param string       $url             URL.
+	 * @param array|string $data            Data.
+	 * @param boolean      $return_as_array Return results as associative array.
+	 * @param boolean      $is_file         Is file-related request.
+	 * @param boolean      $debug           Debug this request.
 	 *
 	 * @return array|Result|false
 	 */


### PR DESCRIPTION
Fixes #119  
Part of #73

Separating the easy from the possible controversial part. 