### PR TITLE
Set ignore_errors flag for HTTP requests in PHP client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Remove trailing slash from endpoint url by [@Procta].
 - Added local cache to getResolutions by [@jpastoor].
 - Renamed Api::api() parameter $return_as_json to $return_as_array by [@jpastoor].
+- ignore_errors flag added to HTTP context by [@betterphp].
 
 ### Removed
 ...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - The `Api::getRoles` call was always retuning an error by [@aik099].
 - Attempt to make a `DELETE` API call using `CurlClient` wasn't working by [@aik099].
 - Clearing local caches (statuses, priorities, fields and resolutions) on endpoint change by [@jpastoor].
-- ignore_errors flag added to HTTP context by [@betterphp].
+- Error details from failed API calls were not available back from Api::api method call by [@betterphp].
 
 ## [1.0.0] - 2014-07-27
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Remove trailing slash from endpoint url by [@Procta].
 - Added local cache to getResolutions by [@jpastoor].
 - Renamed Api::api() parameter $return_as_json to $return_as_array by [@jpastoor].
-- ignore_errors flag added to HTTP context by [@betterphp].
 
 ### Removed
 ...
@@ -38,6 +37,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - The `Api::getRoles` call was always retuning an error by [@aik099].
 - Attempt to make a `DELETE` API call using `CurlClient` wasn't working by [@aik099].
 - Clearing local caches (statuses, priorities, fields and resolutions) on endpoint change by [@jpastoor].
+- ignore_errors flag added to HTTP context by [@betterphp].
 
 ## [1.0.0] - 2014-07-27
 ### Added
@@ -60,3 +60,4 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 [@digitalkaoz]: https://github.com/digitalkaoz
 [@DerMika]: https://github.com/DerMika
 [@aik099]: https://github.com/aik099
+[@betterphp]: https://github.com/betterphp

--- a/src/Jira/Api/Client/PHPClient.php
+++ b/src/Jira/Api/Client/PHPClient.php
@@ -122,6 +122,7 @@ class PHPClient implements ClientInterface
 			'http' => array(
 				'method' => $method,
 				'header' => implode("\r\n", $header),
+				'ignore_errors' => true,
 			),
 		);
 

--- a/tests/Jira/Api/Client/AbstractClientTestCase.php
+++ b/tests/Jira/Api/Client/AbstractClientTestCase.php
@@ -36,7 +36,7 @@ abstract class AbstractClientTestCase extends \PHPUnit_Framework_TestCase
 	public function testGetRequestWithKnownHttpCode($http_code)
 	{
 		$data = array('param1' => 'value1', 'param2' => 'value2');
-		$trace_result = $this->traceRequest(Api::REQUEST_GET, array_merge(['http_code' => $http_code], $data));
+		$trace_result = $this->traceRequest(Api::REQUEST_GET, array_merge(array('http_code' => $http_code), $data));
 
 		$this->assertEquals('GET', $trace_result['_SERVER']['REQUEST_METHOD']);
 		$this->assertContentType('application/json;charset=UTF-8', $trace_result);

--- a/tests/Jira/Api/Client/AbstractClientTestCase.php
+++ b/tests/Jira/Api/Client/AbstractClientTestCase.php
@@ -30,14 +30,25 @@ abstract class AbstractClientTestCase extends \PHPUnit_Framework_TestCase
 		$this->client = $this->createClient();
 	}
 
-	public function testGetRequest()
+	/**
+	 * @dataProvider getRequestWithKnownHttpCode
+	 */
+	public function testGetRequestWithKnownHttpCode($http_code)
 	{
 		$data = array('param1' => 'value1', 'param2' => 'value2');
-		$trace_result = $this->traceRequest(Api::REQUEST_GET, $data);
+		$trace_result = $this->traceRequest(Api::REQUEST_GET, array_merge(['http_code' => $http_code], $data));
 
 		$this->assertEquals('GET', $trace_result['_SERVER']['REQUEST_METHOD']);
 		$this->assertContentType('application/json;charset=UTF-8', $trace_result);
 		$this->assertEquals($data, $trace_result['_GET']);
+	}
+
+	public function getRequestWithKnownHttpCode()
+	{
+		return array(
+			'http 200' => array(200),
+			'http 403' => array(403),
+		);
 	}
 
 	/**
@@ -183,11 +194,6 @@ abstract class AbstractClientTestCase extends \PHPUnit_Framework_TestCase
 			'http 201' => array(201),
 			'http 204' => array(204),
 		);
-	}
-
-	public function testErrorResponseValueReturned()
-	{
-		$this->traceRequest(Api::REQUEST_GET, array('http_code' => '403', 'response_mode' => 'trace'));
 	}
 
 	/**

--- a/tests/Jira/Api/Client/AbstractClientTestCase.php
+++ b/tests/Jira/Api/Client/AbstractClientTestCase.php
@@ -185,6 +185,11 @@ abstract class AbstractClientTestCase extends \PHPUnit_Framework_TestCase
 		);
 	}
 
+	public function testErrorResponseValueReturned()
+	{
+		$this->traceRequest(Api::REQUEST_GET, array('http_code' => '403', 'response_mode' => 'trace'));
+	}
+
 	/**
 	 * Checks, that request contained specified content type.
 	 *

--- a/tests/Jira/Api/Client/AbstractClientTestCase.php
+++ b/tests/Jira/Api/Client/AbstractClientTestCase.php
@@ -31,7 +31,7 @@ abstract class AbstractClientTestCase extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * @dataProvider getRequestWithKnownHttpCode
+	 * @dataProvider getRequestWithKnownHttpCodeDataProvider
 	 */
 	public function testGetRequestWithKnownHttpCode($http_code)
 	{
@@ -43,7 +43,7 @@ abstract class AbstractClientTestCase extends \PHPUnit_Framework_TestCase
 		$this->assertEquals($data, $trace_result['_GET']);
 	}
 
-	public function getRequestWithKnownHttpCode()
+	public function getRequestWithKnownHttpCodeDataProvider()
 	{
 		return array(
 			'http 200' => array(200),


### PR DESCRIPTION
By default when a HTTP code other than 200 is returned file_get_contents does not return the content. Setting this flag means that the data is always returned and error messages from JIRA can be parsed correctly