### PR TITLE
Disable CURLOPT_HTTP_VERSION override

### DIFF
--- a/src/Jira/Api/Client/CurlClient.php
+++ b/src/Jira/Api/Client/CurlClient.php
@@ -93,7 +93,6 @@ class CurlClient implements ClientInterface
 			curl_setopt($curl, CURLOPT_USERPWD, sprintf('%s:%s', $credential->getId(), $credential->getPassword()));
 		}
 
-// 		curl_setopt($curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_0);
 		curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false);
 		curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, 0);
 		curl_setopt($curl, CURLOPT_VERBOSE, $debug);

--- a/src/Jira/Api/Client/CurlClient.php
+++ b/src/Jira/Api/Client/CurlClient.php
@@ -93,7 +93,7 @@ class CurlClient implements ClientInterface
 			curl_setopt($curl, CURLOPT_USERPWD, sprintf('%s:%s', $credential->getId(), $credential->getPassword()));
 		}
 
-		curl_setopt($curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_0);
+// 		curl_setopt($curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_0);
 		curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false);
 		curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, 0);
 		curl_setopt($curl, CURLOPT_VERBOSE, $debug);


### PR DESCRIPTION
Forcing CURLOPT_HTTP_VERSION to CURL_HTTP_VERSION_1_0 results in "SSLRead() return error -9806" error when connecting making a request to JIRA.