### PR TITLE
Set timeout for fail gracefully

### DIFF
--- a/src/Jira/Api/Client/CurlClient.php
+++ b/src/Jira/Api/Client/CurlClient.php
@@ -93,6 +93,7 @@ class CurlClient implements ClientInterface
 			curl_setopt($curl, CURLOPT_USERPWD, sprintf('%s:%s', $credential->getId(), $credential->getPassword()));
 		}
 
+		curl_setopt($curl, CURLOPT_TIMEOUT, 30);
 		curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false);
 		curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, 0);
 		curl_setopt($curl, CURLOPT_VERBOSE, $debug);

--- a/src/Jira/Api/Client/CurlClient.php
+++ b/src/Jira/Api/Client/CurlClient.php
@@ -33,6 +33,12 @@ use chobie\Jira\Api\UnauthorizedException;
 
 class CurlClient implements ClientInterface
 {
+	/**
+	 * Default timeout for CURL requests
+	 *
+	 * @var int seconds
+	 */
+	protected $timeout = 10;
 
 	/**
 	 * create a traditional php client
@@ -93,7 +99,9 @@ class CurlClient implements ClientInterface
 			curl_setopt($curl, CURLOPT_USERPWD, sprintf('%s:%s', $credential->getId(), $credential->getPassword()));
 		}
 
-		curl_setopt($curl, CURLOPT_TIMEOUT, 30);
+		if (is_numeric($this->timeout)) {
+			curl_setopt($curl, CURLOPT_TIMEOUT, $this->timeout);
+		}
 		curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false);
 		curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, 0);
 		curl_setopt($curl, CURLOPT_VERBOSE, $debug);

--- a/tests/Jira/Api/Client/CurlClientTest.php
+++ b/tests/Jira/Api/Client/CurlClientTest.php
@@ -19,4 +19,8 @@ class CurlClientTest extends AbstractClientTestCase
 		return new CurlClient();
 	}
 
+	protected function testTimeout()
+	{
+		return new CurlClient();
+	}
 }


### PR DESCRIPTION
Sometime JIRA server is down/moved and API takes forever to respond. So consistent timeout address this issue and fail with message that "JIRA server have timed out after 30000 mili seconds"