### PR TITLE
Allow Empty Result

### DIFF
--- a/src/Jira/Api/Result.php
+++ b/src/Jira/Api/Result.php
@@ -70,7 +70,7 @@ class Result
 	 *
 	 * @param array $result Result.
 	 */
-	public function __construct(array $result)
+	public function __construct(array $result = array())
 	{
 		if ( isset($result['expand']) ) {
 			$this->expand = explode(',', $result['expand']);


### PR DESCRIPTION
This fixes: "Argument 1 passed to chobie//Jira//Api//Result::__construct() must be of the type array, null given, called in /var/www/site/vendor/chobie/jira-api-restclient/src/Jira/Api.php on line 748 and defined...." Potentially, there should be some sort of indication that the result is not a success