### PR TITLE
Support "scope" as part of an IssueType

### DIFF
--- a/src/Jira/IssueType.php
+++ b/src/Jira/IssueType.php
@@ -90,6 +90,7 @@ class IssueType
 		'name',
 		'subtask',
 		'avatarId',
+		'scope',
 	);
 
 	/**


### PR DESCRIPTION
Scope is a new key that can be found on the issuetypes array. 
Since this is not whitelisted on the acceptableKeys array, if this function is needed for anything and the project have a scope, the process dies before reaching out the end of the execution.

The existence of the scope key can be found on the api documentation: https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-api-2-issue-createmeta-get