### PR TITLE
rename createRemotelink -> createRemoteLink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Remove trailing slash from endpoint url by [@Procta].
 - Added local cache to getResolutions by [@jpastoor].
 - Renamed Api::api() parameter $return_as_json to $return_as_array by [@jpastoor].
+- Renamed `Api::createRemotelink` to `Api::createRemoteLink` by [@glensc].
 
 ### Removed
 ...

--- a/src/Jira/Api.php
+++ b/src/Jira/Api.php
@@ -676,7 +676,7 @@ class Api
 	 * @return array|false
 	 * @since  2.0.0
 	 */
-	public function createRemotelink(
+	public function createRemoteLink(
 		$issue_key,
 		array $object = array(),
 		$relationship = null,


### PR DESCRIPTION
Fixes "1" from #120:

- it's name violates camelCase naming rules, where each word (except 1st one) in method name must be capitalized (should be Api::createRemoteLink)

method names are case insensitive in PHP, unless there's some magic getters/setters behind, this change is backward compatible.

cc @aik099 