### PR TITLE
Setup .gitattributes for better changelog merges

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# merge=union strategy for changelog
+# http://krlmlr.github.io/using-gitattributes-to-avoid-merge-conflicts/
+/CHANGELOG.md merge=union

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Allow configuring issues queried per page in `Walker` class by [@aik099].
 - Added optional override for the filename in `Api::createAttachment` by [@betterphp]
 - Allow getting issue count back from `Walker` class by [@aik099].
+- Setup `.gitattributes` for better `CHANGELOG.md` merging by [@glensc].
 
 ### Changed
 - Classes/interfaces were renamed to use namespaces by [@chobie].


### PR DESCRIPTION
While github.com still doesn't support this in their web, this has an effect on rebase/merges.

ps: gitlab.com web supports this ;)
- https://gitlab.com/gitlab-org/gitlab-ce/issues/17325